### PR TITLE
执行命令和发送命令到窗口两个快捷键容易混淆，大多数情况都是代码片段，直接enter以后无法执行。

### DIFF
--- a/cherry-snippet.ahk
+++ b/cherry-snippet.ahk
@@ -992,8 +992,10 @@ handle_command(command)
         execute_python(UnityPath)
     else if(SubStr(UnityPath, 1, 5) == "::bat")
         execute_bat(UnityPath)
+    else if(SubStr(UnityPath, 1, 3) == ";v1" || SubStr(UnityPath, 1, 3) == "run")
+    	ExecScript(UnityPath, A_ScriptDir, A_ScriptDir "\v1\AutoHotkey.exe")
     else
-        ExecScript(UnityPath, A_ScriptDir, A_ScriptDir "\v1\AutoHotkey.exe")
+        send_command(command)
 }
 
 db_parse(DB)


### PR DESCRIPTION
在enter执行命令前判断;v1开头或者run开头认为是v1脚本执行，否则任务是代码片段，执行发送命令到窗口动作，进行兼容